### PR TITLE
fix: Alias field is made unrequired for accessing the Deploy Button

### DIFF
--- a/src/pages/ApplicationPage/tabs/ApplicationPageTabDeploy/ApplicationPageTabDeploy.tsx
+++ b/src/pages/ApplicationPage/tabs/ApplicationPageTabDeploy/ApplicationPageTabDeploy.tsx
@@ -50,16 +50,11 @@ export const ApplicationPageTabDeploy = ({
 }: IApplicationPageTabDeployProps) => {
   const classes = useStyles()
   const [vers, setVers] = React.useState(possibleVersions[possibleVersions.length - 1])
-  const [alias, setAlias] = React.useState('')
   const handleVersionChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setVers(event.target.value as string)
   }
-  const handleAliasChange = (event: React.ChangeEvent<{ value: string }>) => {
-    setAlias(event.target.value)
-  }
   const onClickDeploy = () => {
     setVers('')
-    setAlias('')
   }
   console.log(templateVersion)
   return (
@@ -87,18 +82,11 @@ export const ApplicationPageTabDeploy = ({
                   </MenuItem>
                 ))}
               </Select>
-              <TextField
-                required
-                id='standard-required'
-                label='Required'
-                variant='filled'
-                value={alias}
-                onChange={handleAliasChange}
-              />
+              <TextField id='standard-required' label='Alias' variant='filled' />
             </FormControl>
           </Grid>
           <Grid item className={classes.buttonContainerStyle}>
-            <Button variant='contained' disabled={!vers || !alias} onClick={onClickDeploy}>
+            <Button variant='contained' disabled={!vers} onClick={onClickDeploy}>
               Deploy
             </Button>
           </Grid>

--- a/src/pages/ApplicationPage/tabs/ApplicationPageTabDeploy/ApplicationPageTabDeploy.tsx
+++ b/src/pages/ApplicationPage/tabs/ApplicationPageTabDeploy/ApplicationPageTabDeploy.tsx
@@ -50,11 +50,16 @@ export const ApplicationPageTabDeploy = ({
 }: IApplicationPageTabDeployProps) => {
   const classes = useStyles()
   const [vers, setVers] = React.useState(possibleVersions[possibleVersions.length - 1])
+  const [alias, setAlias] = React.useState('')
   const handleVersionChange = (event: React.ChangeEvent<{ value: unknown }>) => {
     setVers(event.target.value as string)
   }
+  const handleAliasChange = (event: React.ChangeEvent<{ value: string }>) => {
+    setAlias(event.target.value)
+  }
   const onClickDeploy = () => {
     setVers('')
+    setAlias('')
   }
   console.log(templateVersion)
   return (
@@ -82,7 +87,13 @@ export const ApplicationPageTabDeploy = ({
                   </MenuItem>
                 ))}
               </Select>
-              <TextField id='standard-required' label='Alias' variant='filled' />
+              <TextField
+                id='standard-required'
+                label='Alias'
+                variant='filled'
+                value={alias}
+                onChange={handleAliasChange}
+              />
             </FormControl>
           </Grid>
           <Grid item className={classes.buttonContainerStyle}>


### PR DESCRIPTION
Alias field is made optional for accessing the Deploy Button